### PR TITLE
Update proposed Overlay changes

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -23,7 +23,7 @@ TBD
 	- [Schema](#schema)
 		- [Overlay Object](#overlayObject)
 		- [Info Object](#infoObject)
-		- [Update Object](#updateObject)
+		- [Action Object](#actionObject)
 	- [Examples](#examples)
 	- [Specification Extensions](#specificationExtensions)
 - [Appendix A: Revision History](#revisionHistory)
@@ -32,7 +32,7 @@ TBD
 ## Definitions
 
 ##### <a name="overlayDocument"></a>Overlay Document
-An overlay document contains an ordered list of [Update Objects](#overlayUpdates) that are to be applied to the target document. Each [Update Object](#updateObject) has a `target` property and a modifier type (`add`, `merge`, or `remove`).  The `target` property is a [JMESPath](https://jmespath.org/specification.html) query that identifies what part of the target document is to be updated and the modifier determines the change.
+An overlay document contains an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`).  The `target` property is a [JMESPath](https://jmespath.org/specification.html) query that identifies what part of the target document is to be updated and the modifier determines the change.
 
 ## Specification
 
@@ -80,11 +80,11 @@ Field Name | Type | Description
 <a name="overlayVersion"></a>overlay | `string` | **REQUIRED**. This string MUST be the [version number](#versions) of the Overlay Specification that the Overlay document uses. The `overlay` field SHOULD be used by tooling to interpret the Overlay document. 
 <a name="overlayInfo"></a>info | [Info Object](#infoObject) | **REQUIRED**. Provides metadata about the Overlay. The metadata MAY be used by tooling as required.
 <a name="overlayExtends"></a> extends | `string` | URL to the target document (such as an OpenAPI document) this overlay applies to. This MUST be in the form of a URL.
-<a name="overlayUpdates"></a>updates | [[Update Object](#updateObject)] | **REQUIRED** An ordered list of update objects to be applied to the target document. The array MUST contain at least one value.
+<a name="overlayActions"></a>actions | [[Action Object](#actionObject)] | **REQUIRED** An ordered list of actions to be applied to the target document. The array MUST contain at least one value.
 
-*** This object MAY be extended with [Specification Extensions](#specificationExtensions). ***
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-The list of update objects MUST be applied in sequential order to ensure a consistent outcome. Updates are applied to the result of the previous updates. This enables objects to be deleted in one update and then re-created in a subsequent update, for example.
+The list of actions MUST be applied in sequential order to ensure a consistent outcome. Actions are applied to the result of the previous updates. This enables objects to be deleted in one update and then re-created in a subsequent update, for example.
 
 The `extends` property can be used to indicate that the Overlay was designed to update a specific OpenAPI document. Where no `extends` is provided it is the responsibility of tooling to apply the Overlay documents to the appropriate OpenAPI document(s).
 
@@ -101,9 +101,9 @@ Field Name | Type | Description
 <a name="infoVersion"></a>version | `string` | **REQUIRED**. A version identifer for indicating changes to the Overlay document.
 
 
-*** This object MAY be extended with [Specification Extensions](#specificationExtensions). ***
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-#### <a name="updateObject"></a>Update Object
+#### <a name="actionObject"></a>Action Object
 
 This object represents one or more changes to be applied to the target document at the location defined by the target JMESPath expression.
 
@@ -111,31 +111,31 @@ This object represents one or more changes to be applied to the target document 
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="updateTarget"></a>target | `string` | **REQUIRED** A JMESPath expression referencing the target objects in the target document.
-<a name="updateAdd"></a>add | Any | An object to be added as a child of the object(s) referenced by the `target`. Property has no impact if `remove` property is `true`.
-<a name="updateMerge"></a>merge | Any | An object with the properties and values to be merged with the object(s) referenced by the `target`. Property has no impact if `remove` property is `true`.
-<a name="updateRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
+<a name="actionTarget"></a>target | `string` | **REQUIRED** A JMESPath expression referencing the target objects in the target document.
+<a name="actionDescription"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="actionUpdate"></a>update | Any | An object with the properties and values to be merged with the object(s) referenced by the `target`. This property has no impact if `remove` property is `true`.
+<a name="actionRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
 
 The result of the `target` JMESPath expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.
 
-The properties of the merge object MUST be compatible with the target object referenced by the JMESPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
+The properties of the update object MUST be compatible with the target object referenced by the JMESPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
 
-*** This object MAY be extended with [Specification Extensions](#specificationExtensions). ***
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
 ### Examples
 
 #### Structured Overlays Example
 
-When updating properties throughout the target document it may be more efficient to create a single `Update Object` that mirrors the structure of the target document. e.g.
+When updating properties throughout the target document it may be more efficient to create a single `Action Object` that mirrors the structure of the target document. e.g.
 
 ```yaml
 overlay: 1.0.0
 info:
   title: Structured Overlay
   version: 1.0.0
-updates:
+actions:
 - target: "@"
-  merge:
+  update:
     info:
       x-overlay-applied: structured-overlay
     paths:
@@ -154,22 +154,22 @@ updates:
 
 #### Targeted Overlays
 
-Alternatively, where only a small number of updates need to be applied to a large document, each [Update Object](#updateObject) MAY be more targeted.
+Alternatively, where only a small number of updates need to be applied to a large document, each [Action Object](#actionObject) MAY be more targeted.
 
 ```yaml
 overlay: 1.0.0
 info:
   title: Targeted Overlays
   version: 1.0.0
-updates:
+actions:
 - target: paths."/foo".get
-  merge:
+  update:
     description: This is the new description
 - target: paths."/bar".get
-  merge:
+  update:
     description: This is the updated description
 - target: paths."/bar"
-  merge:
+  update:
     post:
       description: This is an updated description of a child object
       x-safe: false
@@ -184,28 +184,28 @@ overlay: 1.0.0
 info:
   title: Update many objects at once
   version: 1.0.0
-updates:
+actions:
 - target: paths.*.get
-  merge:
+  update:
     x-safe: true
 - target: paths.*.get.parameters[?name=='filter' && in=='query']
-  merge:
+  update:
     schema:
       $ref: "/components/schemas/filterSchema"
 ```
 
 #### Array Modification Examples
 
-Array elements MAY be added using the 'add' modifier type. Array elements MAY be deleted using the `remove` property.  Use of array indexes to remove array items should be avoided where possible as indexes will change when items are removed.  Update modifier type 'merge' MUST NOT be used with arrays.
+Array elements MAY be deleted using the `remove` property.  Use of array indexes to remove array items should be avoided where possible as indexes will change when items are removed.
 
 ```yaml
 overlay: 1.0.0
 info:
   title: Add an array element
   version: 1.0.0
-updates:
+actions:
 - target: paths.*.get.parameters
-  add:
+  update:
     name: newParam
     in: query
 ```
@@ -215,7 +215,7 @@ overlay: 1.0.0
 info:
   title: Remove a array element
   version: 1.0.0
-updates:
+actions:
 - target: paths[*].get.parameters[? name == 'dummy']
   remove: true
 ```
@@ -245,9 +245,9 @@ overlay: 1.0.0
 info:
   title: Apply Traits
   version: 1.0.0
-updates:
+actions:
 - target: $.paths[*].get[?contains(x-traits,'paged')]
-  merge:
+  update:
     parameters:
       - name: top
         in: query


### PR DESCRIPTION
Following the discussion in the slack channel, the following changes have been implemented:

- Rename `updates` to `actions` (including object name)
- Merge `merge` and `add` into one action type, and renaming it to `update`
- Allow for extensions
- Added `description` field to what is now known as the `Action Object`

At the moment, JMESPath has not been replaced with JSONPath.