### PR TITLE
Changed the query language from JMESPath to JSONPath

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -32,7 +32,7 @@ TBD
 ## Definitions
 
 ##### <a name="overlayDocument"></a>Overlay Document
-An overlay document contains an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`).  The `target` property is a [JMESPath](https://jmespath.org/specification.html) query that identifies what part of the target document is to be updated and the modifier determines the change.
+An overlay document contains an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`).  The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
 
 ## Specification
 
@@ -54,7 +54,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 ### <a name="documentStructure"></a>Document Structure
 
-It is RECOMMENDED that the root Overlay document be named: TBD.
+It is RECOMMENDED that the root Overlay document be named: overlay.json or overlay.yaml.
 
 ### <a name="dataTypes"></a>Data Types
 
@@ -111,14 +111,14 @@ This object represents one or more changes to be applied to the target document 
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="actionTarget"></a>target | `string` | **REQUIRED** A JMESPath expression referencing the target objects in the target document.
+<a name="actionTarget"></a>target | `string` | **REQUIRED** A JSONPath query expression referencing the target objects in the target document.
 <a name="actionDescription"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
 <a name="actionUpdate"></a>update | Any | An object with the properties and values to be merged with the object(s) referenced by the `target`. This property has no impact if `remove` property is `true`.
 <a name="actionRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
 
-The result of the `target` JMESPath expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.
+The result of the `target` JSONPath query expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.
 
-The properties of the update object MUST be compatible with the target object referenced by the JMESPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
+The properties of the update object MUST be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
@@ -134,7 +134,7 @@ info:
   title: Structured Overlay
   version: 1.0.0
 actions:
-- target: "@"
+- target: "$"   # Root of document
   update:
     info:
       x-overlay-applied: structured-overlay
@@ -162,13 +162,13 @@ info:
   title: Targeted Overlays
   version: 1.0.0
 actions:
-- target: paths."/foo".get
+- target: $.paths./foo.get
   update:
     description: This is the new description
-- target: paths."/bar".get
+- target: $.paths./bar.get
   update:
     description: This is the updated description
-- target: paths."/bar"
+- target: $.paths./bar
   update:
     post:
       description: This is an updated description of a child object
@@ -185,10 +185,10 @@ info:
   title: Update many objects at once
   version: 1.0.0
 actions:
-- target: paths.*.get
+- target: $.paths.*.get
   update:
     x-safe: true
-- target: paths.*.get.parameters[?name=='filter' && in=='query']
+- target: $.paths.*.get.parameters[?(@.name=='filter' && @.in=='query')]
   update:
     schema:
       $ref: "/components/schemas/filterSchema"
@@ -204,7 +204,7 @@ info:
   title: Add an array element
   version: 1.0.0
 actions:
-- target: paths.*.get.parameters
+- target: $.paths.*.get.parameters
   update:
     name: newParam
     in: query
@@ -216,7 +216,7 @@ info:
   title: Remove a array element
   version: 1.0.0
 actions:
-- target: paths[*].get.parameters[? name == 'dummy']
+- target: $.paths.*.get.parameters[?(@.name == 'dummy')]
   remove: true
 ```
 
@@ -246,7 +246,7 @@ info:
   title: Apply Traits
   version: 1.0.0
 actions:
-- target: $.paths[*].get[?contains(x-traits,'paged')]
+- target: $.paths.*.get[?(@.x-traits.paged)]
   update:
     parameters:
       - name: top


### PR DESCRIPTION
Updated the proposal to use JSONPath based on the current draft https://www.ietf.org/id/draft-ietf-jsonpath-base-04.html

JMESPath was originally selected because it had a specification and an extensive test suite.  However, experimentation has shown that JMESPath is optimized to transforming the input JSON document into an output JSON document.  The goal is to select and project.  However, for Overlays, the objective is to select a set of elements in the target document.  There is no need for the ability to project new JSON objects.

Since the original draft of the Overlay specification was created, there has been an effort in the IETF to standardize the JSONPath specification.  The original JSONPath definition relied on scripting support from the underlying implementation.  This would not be suitable for the Overlay specification.  The new IETF version is taking efforts to make the JSONPath use a fully specified query expression that is not implementation dependent. 