### PR TITLE
JSON Path update fixes (and others)

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -246,7 +246,7 @@ info:
   title: Apply Traits
   version: 1.0.0
 actions:
-- target: $.paths.*.get[?@.x-traits.paged]
+- target: $.paths.*.get[?@.x-oai-traits.paged]
   update:
     parameters:
       - name: top

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -162,13 +162,13 @@ info:
   title: Targeted Overlays
   version: 1.0.0
 actions:
-- target: $.paths./foo.get
+- target: $.paths['/foo'].get
   update:
     description: This is the new description
-- target: $.paths./bar.get
+- target: $.paths['/bar'].get
   update:
     description: This is the updated description
-- target: $.paths./bar
+- target: $.paths['/bar']
   update:
     post:
       description: This is an updated description of a child object

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -188,7 +188,7 @@ actions:
 - target: $.paths.*.get
   update:
     x-safe: true
-- target: $.paths.*.get.parameters[?(@.name=='filter' && @.in=='query')]
+- target: $.paths.*.get.parameters[?@.name=='filter' && @.in=='query']
   update:
     schema:
       $ref: "/components/schemas/filterSchema"
@@ -216,7 +216,7 @@ info:
   title: Remove a array element
   version: 1.0.0
 actions:
-- target: $.paths.*.get.parameters[?(@.name == 'dummy')]
+- target: $.paths.*.get.parameters[?@.name == 'dummy']
   remove: true
 ```
 
@@ -246,7 +246,7 @@ info:
   title: Apply Traits
   version: 1.0.0
 actions:
-- target: $.paths.*.get[?(@.x-traits.paged)]
+- target: $.paths.*.get[?@.x-traits.paged]
   update:
     parameters:
       - name: top

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -177,7 +177,7 @@ actions:
 
 #### Wildcard Overlays Examples
 
-One significant advantage of using the JMESPath syntax is that it allows referencing multiple nodes in the target document.  This would allow a single update object to be applied to multiple target objects using wildcards.
+One significant advantage of using the JSONPath syntax is that it allows referencing multiple nodes in the target document.  This would allow a single update object to be applied to multiple target objects using wildcards and other multi-value selectors.
 
 ```yaml
 overlay: 1.0.0


### PR DESCRIPTION
After seeing https://github.com/OAI/Overlay-Specification/pull/18, I thought it would be good to review for JSON Path usage.

Of note:

- dot syntax is only allowed for alphanumeric and underscore
- parentheses on filter expressions isn't required anymore

I've also found a couple other minor issues.

---

There is additionally one thing we should probably call out.  JSON Path has the ability to return the same node multiple times in the same query.  We probably don't want to apply the modifier multiple times to a single location.