### PR TITLE
Fixed a leftover JMESPath instance, should be JSONPath

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -105,7 +105,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 #### <a name="actionObject"></a>Action Object
 
-This object represents one or more changes to be applied to the target document at the location defined by the target JMESPath expression.
+This object represents one or more changes to be applied to the target document at the location defined by the target JSONPath expression.
 
 ##### Fixed Fields
 


### PR DESCRIPTION
We recently switched from JMESPath to JSONPath in Overlays, but I found a stray JMESPath left in the wording. This pull request updates it.