### PR TITLE
Add an intro and other missing sections

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -11,9 +11,9 @@ This document is licensed under [The Apache License, Version 2.0](https://www.ap
 The Overlay specification is an extension or companion to the OpenAPI specification.
 An Overlay describes a set of changes to be applied or "overlaid" onto an existing OpenAPI description.
 
-The main purpose of Overlays is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
+The main purpose of the Overlay Specification is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
 Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
-Overlays may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.
+An Overlay may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.
 
 ## Table of Contents
 
@@ -35,8 +35,9 @@ Overlays may be specific to a single OpenAPI description, or be designed to appl
 
 ## Definitions
 
-##### <a name="overlayDocument"></a>Overlay Document
-An overlay document contains an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`).  The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
+##### <a name="overlayDocument"></a>Overlay
+
+An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`).  The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
 
 ## Specification
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -11,7 +11,7 @@ This document is licensed under [The Apache License, Version 2.0](https://www.ap
 The Overlay specification is an extension or companion to the OpenAPI specification.
 An Overlay describes a set of changes to be applied or "overlaid" onto an existing OpenAPI document.
 
-The main purpose of Overlays to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
+The main purpose of Overlays is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
 Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
 Overlays may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.
 
@@ -42,9 +42,9 @@ An overlay document contains an ordered list of [Action Objects](#overlayActions
 
 ### Versions
 
-The Overlay Specification is versioned using a `major`.`minor`.`patch` versioning scheme. The `major`.`minor` portion of the version string (for example 1.0) SHALL designate the Arazzo feature set. `.patch` versions address errors in, or provide clarifications to, this document, not the feature set. The patch version SHOULD NOT be considered by tooling, making no distinction between 1.0.0 and 1.0.1 for example.
+The Overlay Specification is versioned using a `major`.`minor`.`patch` versioning scheme. The `major`.`minor` portion of the version string (for example 1.0) SHALL designate the Overlay feature set. `.patch` versions address errors in, or provide clarifications to, this document, not the feature set. The patch version SHOULD NOT be considered by tooling, making no distinction between 1.0.0 and 1.0.1 for example.
 
-**Note:** Version 1.0.0 of the Overlay Specification is being released after spending some time in draft, and after being adopted by tools providers.
+**Note:** Version 1.0.0 of the Overlay Specification is being released after spending some time in draft, and after being adopted by tool providers.
 Check with your tool provider for the details of what is supported in each tool.
 
 ### Format

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -8,7 +8,12 @@ This document is licensed under [The Apache License, Version 2.0](https://www.ap
 
 ## Introduction
 
-TBD
+The Overlay specification is an extension or companion to the OpenAPI specification.
+An Overlay describes a set of changes to be applied or "overlaid" onto an existing OpenAPI document.
+
+The main purpose of Overlays to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
+Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
+Overlays may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.
 
 ## Table of Contents
 
@@ -27,7 +32,6 @@ TBD
 	- [Examples](#examples)
 	- [Specification Extensions](#specificationExtensions)
 - [Appendix A: Revision History](#revisionHistory)
-	
 
 ## Definitions
 
@@ -38,7 +42,10 @@ An overlay document contains an ordered list of [Action Objects](#overlayActions
 
 ### Versions
 
-TBD
+The Overlay Specification is versioned using a `major`.`minor`.`patch` versioning scheme. The `major`.`minor` portion of the version string (for example 1.0) SHALL designate the Arazzo feature set. `.patch` versions address errors in, or provide clarifications to, this document, not the feature set. The patch version SHOULD NOT be considered by tooling, making no distinction between 1.0.0 and 1.0.1 for example.
+
+**Note:** Version 1.0.0 of the Overlay Specification is being released after spending some time in draft, and after being adopted by tools providers.
+Check with your tool provider for the details of what is supported in each tool.
 
 ### Format
 
@@ -55,10 +62,6 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 ### <a name="documentStructure"></a>Document Structure
 
 It is RECOMMENDED that the root Overlay document be named: overlay.json or overlay.yaml.
-
-### <a name="dataTypes"></a>Data Types
-
-TBD
 
 ### <a name="relativeReferencesURL"></a>Relative References in URLs
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -19,7 +19,7 @@ An Overlay may be specific to a single OpenAPI description, or be designed to ap
 
 ### Overlay
 
-An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`). The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
+An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlay-actions) that are to be applied to the target document. Each [Action Object](#action-object) has a `target` property and a modifier type (`update` or `remove`). The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
 
 ## Specification
 
@@ -57,7 +57,7 @@ In the following description, if a field is not explicitly **REQUIRED** or descr
 
 #### Overlay Object
 
-This is the root object of the [Overlay document](#overlay-document).
+This is the root object of the [Overlay](#overlay).
 
 ##### Fixed Fields
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -19,7 +19,7 @@ An Overlay may be specific to a single OpenAPI description, or be designed to ap
 
 ### Overlay
 
-An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlay-actions) that are to be applied to the target document. Each [Action Object](#action-object) has a `target` property and a modifier type (`update` or `remove`). The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
+An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlay-actions) that are to be applied to the target document. Each [Action Object](#action-object) has a `target` property and a modifier type (`update` or `remove`). The `target` property is a [[RFC9535|JSONPath]] query expression that identifies the elements of the target document to be updated and the modifier determines the change.
 
 ## Specification
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -9,7 +9,7 @@ This document is licensed under [The Apache License, Version 2.0](https://www.ap
 ## Introduction
 
 The Overlay specification is an extension or companion to the OpenAPI specification.
-An Overlay describes a set of changes to be applied or "overlaid" onto an existing OpenAPI document.
+An Overlay describes a set of changes to be applied or "overlaid" onto an existing OpenAPI description.
 
 The main purpose of Overlays is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
 Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -19,7 +19,7 @@ An Overlay may be specific to a single OpenAPI description, or be designed to ap
 
 ### Overlay
 
-An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`).  The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
+An Overlay is a JSON or YAML structure containing an ordered list of [Action Objects](#overlayActions) that are to be applied to the target document. Each [Action Object](#actionObject) has a `target` property and a modifier type (`update` or `remove`). The `target` property is a [JSONPath](https://datatracker.ietf.org/wg/jsonpath/documents/) query expression that identifies the elements of the target document to be updated and the modifier determines the change.
 
 ## Specification
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -8,7 +8,7 @@ This document is licensed under [The Apache License, Version 2.0](https://www.ap
 
 ## Introduction
 
-The Overlay specification is an extension or companion to the OpenAPI specification.
+The Overlay Specification is an extension or companion to the [[OpenAPI]] specification.
 An Overlay describes a set of changes to be applied or "overlaid" onto an existing OpenAPI description.
 
 The main purpose of the Overlay Specification is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.


### PR DESCRIPTION
We had some "TBD" sections, I removed one (data types, I don't think we can add this after so many people have implemented, and Overlays could span multiple OpenAPI versions!?!?), wrote an intro, and used a version of the Arazzo wording, acknowledging the retroactive nature of the 1.0.0 version specifically.

Hopefully this fills the main gaps! Fixes #44 