### PR TITLE
Clarify the update behaviour for arrays as well as objects

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -113,7 +113,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="actionTarget"></a>target | `string` | **REQUIRED** A JSONPath query expression referencing the target objects in the target document.
 <a name="actionDescription"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="actionUpdate"></a>update | Any | If the `target` is an object, an object with the properties and values to merge with the `target`. If the `target` is an array, an entry to append to the array. To replace an array in its entirety, apply a remove action followed up an update action. This property has no impact if `remove` property is `true`.
+<a name="actionUpdate"></a>update | Any | If the `target` of this action object is an object, this field should be an object with the properties and values to merge with the `target`. If the `target` of this action is an array, this field should be an entry to append to the array. To replace an array in its entirety, apply a remove action followed by an update action. This field has no impact if the `remove` field of this action object is `true`.
 <a name="actionRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
 
 The result of the `target` JSONPath query expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -93,7 +93,7 @@ This object represents one or more changes to be applied to the target document 
 | Field Name | Type | Description |
 | ---- | :----: | ---- |
 | <a name="action-target"></a>target | `string` | **REQUIRED** A JSONPath expression selecting nodes in the target document. |
-| <a name="action-description"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
+| <a name="action-description"></a>description | `string` | A description of the action. [[CommonMark]] syntax MAY be used for rich text representation. |
 | <a name="action-update"></a>update | Any | If the `target` selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the `target` selects an array, the value of this field should be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true`. |
 | <a name="action-remove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`. |
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -97,7 +97,11 @@ This object represents one or more changes to be applied to the target document 
 | <a name="action-update"></a>update | Any | If the `target` selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the `target` selects an array, the value of this field should be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true`. |
 | <a name="action-remove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`. |
 
-The result of the `target` JSONPath expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update or remove a primitive value such as a string, the `target` expression should select the _containing_ object in the target document.
+The result of the `target` JSONPath expression must be zero or more objects or arrays (not primitive types or `null` values).
+
+To update a primitive property value such as a string, the `target` expression should select the _containing_ object in the target document and `update` should contain an object with the property and its new primitive value.
+
+Primitive-valued items of an array cannot be replaced or removed individually, only the complete array can be replaced.
 
 The properties of the update object MUST be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -113,7 +113,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="actionTarget"></a>target | `string` | **REQUIRED** A JSONPath query expression referencing the target objects in the target document.
 <a name="actionDescription"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="actionUpdate"></a>update | Any | If the `target` is an object, an object with the properties and values to merge with the `target`. If the `target` is an array, an entry to append to the array. This property has no impact if `remove` property is `true`.
+<a name="actionUpdate"></a>update | Any | If the `target` is an object, an object with the properties and values to merge with the `target`. If the `target` is an array, an entry to append to the array. To replace an array in its entirety, apply a remove action followed up an update action. This property has no impact if `remove` property is `true`.
 <a name="actionRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
 
 The result of the `target` JSONPath query expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -111,12 +111,12 @@ This object represents one or more changes to be applied to the target document 
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="actionTarget"></a>target | `string` | **REQUIRED** A JSONPath query expression referencing the target objects in the target document.
+<a name="actionTarget"></a>target | `string` | **REQUIRED** A JSONPath expression selecting nodes in the target document.
 <a name="actionDescription"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="actionUpdate"></a>update | Any | If the `target` of this action object is an object, this field should be an object with the properties and values to merge with the `target`. If the `target` of this action is an array, this field should be an entry to append to the array. To replace an array in its entirety, apply a remove action followed by an update action. This field has no impact if the `remove` field of this action object is `true`.
+<a name="actionUpdate"></a>update | Any | If the `target` selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the `target` selects an array, the value of this field should be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true`.
 <a name="actionRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
 
-The result of the `target` JSONPath query expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.
+The result of the `target` JSONPath expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update or remove a primitive value such as a string, the `target` expression should select the *containing* object in the target document.
 
 The properties of the update object MUST be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -113,7 +113,7 @@ Field Name | Type | Description
 ---|:---:|---
 <a name="actionTarget"></a>target | `string` | **REQUIRED** A JSONPath query expression referencing the target objects in the target document.
 <a name="actionDescription"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="actionUpdate"></a>update | Any | An object with the properties and values to be merged with the object(s) referenced by the `target`. This property has no impact if `remove` property is `true`.
+<a name="actionUpdate"></a>update | Any | If the `target` is an object, an object with the properties and values to merge with the `target`. If the `target` is an array, an entry to append to the array. This property has no impact if `remove` property is `true`.
 <a name="actionRemove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
 
 The result of the `target` JSONPath query expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update a primitive value such as a string, the `target` expression should select the *containing* object in the target document.

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -90,14 +90,14 @@ This object represents one or more changes to be applied to the target document 
 
 ##### Fixed Fields
 
-Field Name | Type | Description
----|:---:|---
-<a name="action-target"></a>target | `string` | **REQUIRED** A JSONPath expression selecting nodes in the target document.
-<a name="action-description"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="action-update"></a>update | Any | If the `target` selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the `target` selects an array, the value of this field should be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true`.
-<a name="action-remove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`.
+| Field Name | Type | Description |
+| ---- | :----: | ---- |
+| <a name="action-target"></a>target | `string` | **REQUIRED** A JSONPath expression selecting nodes in the target document. |
+| <a name="action-description"></a>description | `string` | A description of the action. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation. |
+| <a name="action-update"></a>update | Any | If the `target` selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the `target` selects an array, the value of this field should be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true`. |
+| <a name="action-remove"></a>remove | `boolean` | A boolean value that indicates that the target object is to be removed from the the map or array it is contained in. The default value is `false`. |
 
-The result of the `target` JSONPath expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update or remove a primitive value such as a string, the `target` expression should select the *containing* object in the target document.
+The result of the `target` JSONPath expression must be zero or more objects or arrays (not primitive types or `null` values). If you wish to update or remove a primitive value such as a string, the `target` expression should select the _containing_ object in the target document.
 
 The properties of the update object MUST be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.
 


### PR DESCRIPTION
As discussed in a recent meeting [see notes](https://github.com/OAI/Overlay-Specification/discussions/45#discussioncomment-10465119), clarify that for arrays, the update adds an entry but for objects the items are merged ( as is already described)