### PR TITLE
Add respec workflow

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -54,6 +54,7 @@ jobs:
         labels: Housekeeping
         # reviewers: OAI/tsc
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        committer: GitHub <noreply@github.com>
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions
         signoff: false

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -53,10 +53,10 @@ jobs:
         path: deploy
         labels: Housekeeping
         # reviewers: OAI/tsc
-        author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions
-        signoff: true
+        signoff: false
         body: |
           This pull request is automatically triggered by GitHub action `respec` in the OAI/Overlay-Specification repo.
 

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -52,6 +52,7 @@ jobs:
         path: deploy
         labels: Housekeeping
         # reviewers: OAI/tsc
+        author:  github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions
         signoff: true

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,7 +13,6 @@ on:
   push:
     branches:
       - main
-      - respec-workflow # TODO: remove
   workflow_dispatch: {}
 
 jobs:
@@ -52,9 +51,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping
-        # reviewers: OAI/tsc
-        # author: GitHub <noreply@github.com>
-        # committer: GitHub <noreply@github.com>
+        # team-reviewers: OAI/tsc
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions
         signoff: true

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -53,11 +53,11 @@ jobs:
         path: deploy
         labels: Housekeeping
         # reviewers: OAI/tsc
-        author: GitHub <noreply@github.com>
-        committer: GitHub <noreply@github.com>
+        # author: GitHub <noreply@github.com>
+        # committer: GitHub <noreply@github.com>
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions
-        signoff: false
+        signoff: true
         body: |
           This pull request is automatically triggered by GitHub action `respec` in the OAI/Overlay-Specification repo.
 

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+      - respec-workflow # TODO: remove
   workflow_dispatch: {}
 
 jobs:
@@ -35,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4 # checkout gh-pages branch
       with:
         token: ${{ secrets.OAS_REPO_TOKEN }}
-        repository: ralfhandl/OpenAPI-Specification  ## TODO: change to OAI/...
+        repository: ralfhandl/OpenAPI-Specification  # TODO: change to OAI/...
         ref: gh-pages
         path: deploy
 

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -44,7 +44,7 @@ jobs:
       run: scripts/md2html/build.sh
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.OAS_REPO_TOKEN }}
         branch: update-overlay-respec-version

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -53,7 +53,7 @@ jobs:
         path: deploy
         labels: Housekeeping
         # reviewers: OAI/tsc
-        author:  github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions
         signoff: true

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -1,0 +1,62 @@
+name: respec
+
+# author: @MikeRalphson
+# issue: https://github.com/OAI/OpenAPI-Specification/issues/1564
+
+#
+# This workflow updates the respec 'pretty' rendered versions of the spec 
+# on the gh-pages branch when the corresponding markdown files change.
+#
+
+# run this on push to main
+on:
+  push:
+    branches:
+      - main
+      - respec-workflow # temporary
+  workflow_dispatch: {}
+
+jobs:
+  respec:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4 # checkout main branch
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-node@v4 # setup Node.js
+      with:
+        node-version: '20.x'
+    
+    - name: Install dependencies
+      run: npm ci
+
+    - uses: actions/checkout@v4 # checkout gh-pages branch
+      with:
+        token: ${{ secrets.OAS_REPO_TOKEN }}
+        repository: ralfhandl/OpenAPI-Specification  ## change to OAI/...
+        ref: gh-pages
+        path: deploy
+
+    - name: run main script
+      run: scripts/md2html/build.sh
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.OAS_REPO_TOKEN }}
+        branch: update-overlay-respec-version
+        base: gh-pages
+        delete-branch: true
+        path: deploy
+        labels: Housekeeping
+        # reviewers: OAI/tsc
+        title: Update ReSpec-rendered specification versions for Overlay
+        commit-message: Update ReSpec-rendered specification versions
+        signoff: true
+        body: |
+          This pull request is automatically triggered by GitHub action `respec` in the OAI/Overlay-Specification repo.
+
+          The `versions/*.md` files have changed, so the HTML files are automatically being regenerated.

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,7 +13,7 @@ on:
   push:
     branches:
       - main
-      - respec-workflow # TODO: remove
+      - respec-workflow # TODO: remove after testing
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,7 +13,6 @@ on:
   push:
     branches:
       - main
-      - respec-workflow # TODO: remove after testing
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+      - respec-workflow # TODO: remove
   workflow_dispatch: {}
 
 jobs:
@@ -30,7 +31,7 @@ jobs:
         node-version: '20.x'
     
     - name: Install dependencies
-      run: npm install # TODO: npm ci
+      run: npm ci
 
     - uses: actions/checkout@v4 # checkout gh-pages branch
       with:

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,7 +13,7 @@ on:
   push:
     branches:
       - main
-      - respec-workflow # temporary
+      - respec-workflow # TODO: temporary
   workflow_dispatch: {}
 
 jobs:
@@ -31,12 +31,12 @@ jobs:
         node-version: '20.x'
     
     - name: Install dependencies
-      run: npm ci
+      run: npm install # TODO: npm ci
 
     - uses: actions/checkout@v4 # checkout gh-pages branch
       with:
         token: ${{ secrets.OAS_REPO_TOKEN }}
-        repository: ralfhandl/OpenAPI-Specification  ## change to OAI/...
+        repository: ralfhandl/OpenAPI-Specification  ## TODO: change to OAI/...
         ref: gh-pages
         path: deploy
 

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -44,7 +44,7 @@ jobs:
       run: scripts/md2html/build.sh
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.OAS_REPO_TOKEN }}
         branch: update-overlay-respec-version

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -53,7 +53,7 @@ jobs:
         path: deploy
         labels: Housekeeping
         # reviewers: OAI/tsc
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        author: GitHub <noreply@github.com>
         committer: GitHub <noreply@github.com>
         title: Update ReSpec-rendered specification versions for Overlay
         commit-message: Update ReSpec-rendered specification versions

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -13,7 +13,6 @@ on:
   push:
     branches:
       - main
-      - respec-workflow # TODO: temporary
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
Adds workflow to regenerate HTML versions of the Overlay specification

To Do for follow-up PR:
* Create PRs in OAI/OpenAPI-Specification repo once Overlay 1.0 is released

Currently PRs will be created in
* https://github.com/ralfhandl/OpenAPI-Specification/pulls

and will deploy to 
* https://ralfhandl.github.io/OpenAPI-Specification/overlay/v1.0.0.html

which allows us to proof-read the respec-formatted HTML.
