### PR TITLE
Add example of extends property

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -70,15 +70,25 @@ The list of actions MUST be applied in sequential order to ensure a consistent o
 
 The `extends` property can be used to indicate that the Overlay was designed to update a specific [[OpenAPI]] document. Where no `extends` is provided it is the responsibility of tooling to apply the Overlay document to the appropriate OpenAPI document(s).
 
-In the following example the `extends` property specifies that the overlay is designed to update the Redocly Museum OpenAPI document.
+In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document using an absolute URL.
 
 ```yaml
 overlay: 1.0.0
 info:
-  title: Overlay for the Redocly Museum API
+  title: Overlay for the Tic Tac Toe API document
   version: 1.0.0
-extends: 'https://raw.githubusercontent.com/Redocly/museum-openapi-example/refs/heads/main/openapi.yaml'
+extends: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/refs/heads/main/examples/v3.1/tictactoe.yaml'
 ...
+```
+
+The `extends` property can also specify a relative URL. In this case, the URL is resolved relative to the location of the Overlay document.
+
+```yaml
+overlay: 1.0.0
+info:
+  title: Overlay for the Tic Tac Toe API document
+  version: 1.0.0
+extends: './tictactoe.yaml'
 ```
 
 #### Info Object

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -70,6 +70,17 @@ The list of actions MUST be applied in sequential order to ensure a consistent o
 
 The `extends` property can be used to indicate that the Overlay was designed to update a specific [[OpenAPI]] document. Where no `extends` is provided it is the responsibility of tooling to apply the Overlay document to the appropriate OpenAPI document(s).
 
+In the following example the `extends` property specifies that the overlay is designed to update the Redocly Museum OpenAPI document.
+
+```yaml
+overlay: 1.0.0
+info:
+  title: Overlay for the Redocly Museum API
+  version: 1.0.0
+extends: 'https://raw.githubusercontent.com/Redocly/museum-openapi-example/refs/heads/main/openapi.yaml'
+...
+```
+
 #### Info Object
 
 The object provides metadata about the Overlay.


### PR DESCRIPTION
This PR adds a simple example of the `extends` property to illustrate that the property value is a URL to the OpenAPI document that the overlay is designed to update.