### PR TITLE
Updated use of URL to URI

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -73,7 +73,7 @@ The list of actions MUST be applied in sequential order to ensure a consistent o
 
 The `extends` property can be used to indicate that the Overlay was designed to update a specific [[OpenAPI]] document. Where no `extends` is provided it is the responsibility of tooling to apply the Overlay document to the appropriate OpenAPI document(s).
 
-In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document identified by an absolute URI reference.
+In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document, identified by an absolute URI reference.
 
 ```yaml
 overlay: 1.0.0

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -73,7 +73,7 @@ The list of actions MUST be applied in sequential order to ensure a consistent o
 
 The `extends` property can be used to indicate that the Overlay was designed to update a specific [[OpenAPI]] document. Where no `extends` is provided it is the responsibility of tooling to apply the Overlay document to the appropriate OpenAPI document(s).
 
-In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document, identified by an absolute URI reference.
+In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document, identified by an absolute URI.
 
 ```yaml
 overlay: 1.0.0

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -46,10 +46,9 @@ In order to preserve the ability to round-trip between YAML and JSON formats, [[
 - Tags MUST be limited to those allowed by the [JSON Schema ruleset](https://yaml.org/spec/1.2/spec.html#id2803231).
 - Keys used in YAML maps MUST be limited to a scalar string, as defined by the [YAML Failsafe schema ruleset](https://yaml.org/spec/1.2/spec.html#id2802346).
 
-### Relative References in URLs
+### Relative References in URIs
 
-Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
-Unless specified otherwise, relative references are resolved using the URL of the referring document.
+Unless specified otherwise, all fields that are URI references MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2).
 
 ### Schema
 
@@ -65,7 +64,7 @@ This is the root object of the [Overlay](#overlay).
 | ---- | :----: | ---- |
 | <a name="overlay-version"></a>overlay | `string` | **REQUIRED**. This string MUST be the [version number](#versions) of the Overlay Specification that the Overlay document uses. The `overlay` field SHOULD be used by tooling to interpret the Overlay document. |
 | <a name="overlay-info"></a>info | [Info Object](#info-object) | **REQUIRED**. Provides metadata about the Overlay. The metadata MAY be used by tooling as required. |
-| <a name="overlay-extends"></a>extends | `string` | URL to the target document (such as an [[OpenAPI]] document) this overlay applies to. This MUST be in the form of a URL. |
+| <a name="overlay-extends"></a>extends | `string` | URI reference that identifies the target document (such as an [[OpenAPI]] document) this overlay applies to. |
 | <a name="overlay-actions"></a>actions | [[Action Object](#action-object)] | **REQUIRED** An ordered list of actions to be applied to the target document. The array MUST contain at least one value. |
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
@@ -74,7 +73,7 @@ The list of actions MUST be applied in sequential order to ensure a consistent o
 
 The `extends` property can be used to indicate that the Overlay was designed to update a specific [[OpenAPI]] document. Where no `extends` is provided it is the responsibility of tooling to apply the Overlay document to the appropriate OpenAPI document(s).
 
-In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document using an absolute URL.
+In the following example the `extends` property specifies that the overlay is designed to update the OpenAPI Tic Tac Toe example document identified by an absolute URI reference.
 
 ```yaml
 overlay: 1.0.0
@@ -85,7 +84,7 @@ extends: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/refs/heads/ma
 ...
 ```
 
-The `extends` property can also specify a relative URL. In this case, the URL is resolved relative to the location of the Overlay document.
+The `extends` property can also specify a relative URI reference.
 
 ```yaml
 overlay: 1.0.0


### PR DESCRIPTION
This PR attempts to clean up some of the language that was copied from OAS that we have since realized was ambiguous.  It also changes the specification to use URI references instead of URLs for the field extends.

The reason for this change is that we want to give the option for tooling to choose whether to treat the URI reference as an identifier or a locator.  With the previous wording a tooling author may interpret the specification as saying that the tooling is required to dereference the extends URI reference to acquire the target document.  That wouldn't be good, for security reasons and it could lead to users to assume that they can pass an overlay with the extends keyword to tooling that expect to receive an OpenAPI document, because it appears that the Overlay is self contained. (This is similar to how Kubernetes Kustomize overlays can be used https://kubectl.docs.kubernetes.io/guides/config_management/introduction/)

This aligns Overlay's use of URI references with the OAS's use of URI references.