### PR TITLE
Run respec workflow only on original repo

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   respec:
-
+    if: github.repository == 'OAI/Overlay-Specification'
+    
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #91

Use conditional to run respec job only in OAI/Overlay-Specification repo and not in forks.