### PR TITLE
Quick/repeatable agenda creation

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,0 +1,15 @@
+ This discussion is about a meeting of the OpenAPI Overlays group.
+ We meet on alternate Tuesdays at 08:00 Pacific time, and this is a public meeting.
+
+
+
+ Meeting link: 
+
+
+
+ This meeting is covered by the [OpenAPI Initiative Code of Conduct](https://github.com/OAI/Arazzo-Specification/?tab=coc-ov-file#readme).
+
+
+
+ Add comments to this discussion to add items to the agenda for the meeting.
+

--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -22,8 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          variables:
-            | 
+          variables: | 
             body: "${{ env.AGENDA }}"
             title: "Overlays Meeting"
             repositoryId: 'MDEwOlJlcG9zaXRvcnkzNTk4NjU5MDI='

--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -1,0 +1,39 @@
+name: Create meeting template
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  create-discussion:
+    permissions:
+      discussions: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get agenda text from template
+        id: get-agenda
+        run: |
+          echo 'AGENDA<<EOF' >> $GITHUB_ENV
+          cat .github/templates/agenda.md >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Create discussion with agenda
+        id: create-repository-discussion
+        uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          variables:
+            | 
+            body: "${{ env.AGENDA }}"
+            title: "Overlays Meeting"
+            repositoryId: 'MDEwOlJlcG9zaXRvcnkzNTk4NjU5MDI='
+            categoryId: 'DIC_kwDOFXMeLs4COVB8'
+          query: |
+            mutation CreateDiscussionMutation ($title: String!, $body: String!, $repositoryId: ID!, $categoryId: ID!) {
+              createDiscussion(input: { title: $title, body: $body, repositoryId: $repositoryId, categoryId: $categoryId }) {
+                discussion {
+                  title
+                }
+              }
+            }
+


### PR DESCRIPTION
Currently we manually create the meeting agendas. This workflow makes it quicker/easier to do so by creating the discussion with an agenda template in it. Run the action and then add the date and meeting link. If we're happy with it (and once the meeting details for future meetings are certain), we can automate at some point - let's run it under supervision first though.

Uses the GitHub GraphQL API, which has support for GitHub Discussions.