### PR TITLE
Generate minor-version symlinks

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -15,21 +15,31 @@ cp ../../EDITORS.md history/EDITORS_v1.0.0.md
 # temporarily copy installed version of respec into build directory
 cp -p ../../node_modules/respec/builds/respec-w3c.* ../../deploy/js/
 
+# latest=`git describe --abbrev=0 --tags` -- introduce after release tags created
 latest=1.0.0
 latestCopied=none
-for filename in ../../versions/*.md ; do
+lastMinor="-"
+for filename in $(ls -1 ../../versions/[123456789].*.md | sort -r) ; do
   version=$(basename "$filename" .md)
+  minorVersion=${version:0:3}
   tempfile=../../deploy/overlay/v$version-tmp.html
   echo -e "\n=== v$version ==="
+
   node md2html.js --maintainers ./history/EDITORS_v$version.md ${filename} > $tempfile
   npx respec --use-local --src $tempfile --out ../../deploy/overlay/v$version.html
   rm $tempfile
+
   if [ $version = $latest ]; then
     if [[ ${version} != *"rc"* ]];then
       # version is not a Release Candidate
-      cp -p ../../deploy/overlay/v$version.html ../../deploy/overlay/latest.html
+      ( cd ../../deploy/overlay && ln -sf v$version.html latest.html )
       latestCopied=v$version
     fi
+  fi
+
+  if [ ${minorVersion} != ${lastMinor} ]; then
+    ( cd ../../deploy/overlay && ln -sf v$version.html v$minorVersion.html )
+    lastMinor=$minorVersion
   fi
 done
 echo Latest tag is $latest, copied $latestCopied to latest.html


### PR DESCRIPTION
Merge recent changes from OpenAPI and Arazzo publishing workflows:
* `latest.html` is now a symlink instead of a copy
* `v{MAJOR}.{MINOR}.html` symlink that could be referenced in schema YAML file(s)