### PR TITLE
schema test coverage: return code 1 if coverage is below 100%

### DIFF
--- a/scripts/schema-test-coverage.mjs
+++ b/scripts/schema-test-coverage.mjs
@@ -121,6 +121,7 @@ if (notCovered.length > 0) {
   const firstNotCovered = notCovered.slice(0, maxNotCovered);
   if (notCovered.length > maxNotCovered) firstNotCovered.push("...");
   console.log(firstNotCovered);
+  process.exitCode = 1;
 }
 
 console.log(

--- a/scripts/schema-test-coverage.sh
+++ b/scripts/schema-test-coverage.sh
@@ -8,11 +8,15 @@ echo
 echo "Schema Test Coverage"
 echo
 
+rc=0
+
 for schemaDir in schemas/v* ; do
   version=$(basename "$schemaDir")
   echo $version
 
-  node scripts/schema-test-coverage.mjs $schemaDir/schema.yaml tests/$version/pass
+  node scripts/schema-test-coverage.mjs $schemaDir/schema.yaml tests/$version/pass || rc=1
 
   echo
 done
+
+exit $rc


### PR DESCRIPTION
This will cause the schema-test workflow to fail if the schema test coverage drops.

Fixes #107 