### PR TITLE
Workflows with app-generated access token

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -61,7 +61,7 @@ jobs:
         delete-branch: true
         path: deploy
         labels: Housekeeping
-        team-reviewers: OAI/tsc
+        reviewers: darrelmiller,webron,earth2marsh,lornajane,mikekistler,miqui,handrews,ralfhandl
         title: Overlay - Update ReSpec-rendered specification versions
         commit-message: Update ReSpec-rendered specification versions
         signoff: true

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -22,6 +22,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate access token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+        private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
+        owner: OAI
+        repositories: OpenAPI-Specification
+          
     - uses: actions/checkout@v4 # checkout main branch
       with:
         fetch-depth: 0
@@ -35,7 +44,7 @@ jobs:
 
     - uses: actions/checkout@v4 # checkout gh-pages branch
       with:
-        token: ${{ secrets.OAS_REPO_TOKEN }}
+        token: ${{ steps.generate-token.outputs.token }}
         repository: OAI/OpenAPI-Specification  # TODO: change to OAI/...
         ref: gh-pages
         path: deploy
@@ -46,16 +55,14 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
-        # A personal access token is required to push changes to the repository.
-        # This token needs to be refreshed regularly and stored in the repository secrets.
-        token: ${{ secrets.OAS_REPO_TOKEN }}
+        token: ${{ steps.generate-token.outputs.token }}
         branch: update-overlay-respec-version
         base: gh-pages
         delete-branch: true
         path: deploy
         labels: Housekeeping
         team-reviewers: OAI/tsc
-        title: Update ReSpec-rendered specification versions for Overlay
+        title: Overlay - Update ReSpec-rendered specification versions
         commit-message: Update ReSpec-rendered specification versions
         signoff: true
         body: |

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -19,7 +19,7 @@ jobs:
   respec:
     if: github.repository == 'OAI/Overlay-Specification'
     
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Generate access token

--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -18,6 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate access token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
+          owner: OAI
+          repositories: OpenAPI-Specification
+          
       - uses: actions/checkout@v4 # checkout main branch
         with:
           fetch-depth: 0
@@ -31,7 +40,7 @@ jobs:
 
       - uses: actions/checkout@v4 # checkout gh-pages branch
         with:
-          token: ${{ secrets.OAS_REPO_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: OAI/OpenAPI-Specification
           ref: gh-pages
           path: deploy
@@ -42,16 +51,14 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          # A personal access token is required to push changes to the repository.
-          # This token needs to be refreshed regularly and stored in the repository secrets.
-          token: ${{ secrets.OAS_REPO_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           branch: publish-overlay-schema-iteration
           base: gh-pages
           delete-branch: true
           path: deploy
           labels: Housekeeping,Schema
-          reviewers: darrelmiller,webron,earth2marsh,lornajane,mikekistler,miqui,handrews
-          title: Publish Overlay Schema Iterations
+          reviewers: darrelmiller,webron,earth2marsh,lornajane,mikekistler,miqui,handrews,ralfhandl
+          title: Overlay - Publish Schema Iterations
           commit-message: New Overlay schema iterations
           signoff: true
           body: |


### PR DESCRIPTION
Instead of using personal access tokens the two workflows for publishing HTML specs and JSON Schemas now use an app-generated temporary access token.

Same changes as in
* https://github.com/OAI/Arazzo-Specification/pull/302

Example result 
* https://github.com/OAI/OpenAPI-Specification/pull/4277
