### PR TITLE
Add oas-overlay-java to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you are looking for tools to use with Overlays, try these:
 - [apigee-go-gen CLI](https://apigee.github.io/apigee-go-gen/transform/commands/oas-overlay/)
 - [openapi-format CLI/UI](https://github.com/thim81/openapi-format)
 - [oas-patch CLI](https://github.com/mcroissant/oas_patcher)
+- [oas-overlay-java](https://github.com/IBM/oas-overlay-java)
 
 (Is something missing from the list? Send us a pull request to add it!)
 


### PR DESCRIPTION
Add a link to the newly created oas-overlay-java project.
