### PR TITLE
doc: Add Specmatic to the list tools that support Overlay 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you are looking for tools to use with Overlays, try these:
 - [openapi-format CLI/UI](https://github.com/thim81/openapi-format)
 - [oas-patch CLI](https://github.com/mcroissant/oas_patcher)
 - [oas-overlay-java](https://github.com/IBM/oas-overlay-java)
+- [Specmatic](https://specmatic.io/) - [Docs](https://docs.specmatic.io/documentation/contract_tests.html#overlays)
 
 (Is something missing from the list? Send us a pull request to add it!)
 


### PR DESCRIPTION
Specmatic ([https://specmatic.io/](https://specmatic.io/)) added support the Overlay 1.0 specification starting Q4 2024. This includes extending / customizing your OpenAPI specs using OpenAPI overlays for Conract Testing, API Mocking and more.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/13116e1e-0e1d-419b-9738-62331a8540d0" />

Please refer to [documentation](https://docs.specmatic.io/documentation/contract_tests.html#overlays) for more details. Thanks again for the amazing Overlay Spec.