### PR TITLE
Add the meeting link to the new platform

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -3,7 +3,7 @@
 
 
 
- Meeting link: 
+ Meeting link: <https://zoom-lfx.platform.linuxfoundation.org/meeting/99628896838?password=f3ff9796-d6a0-4749-b39e-93dc7eafe7cd>
 
 
 


### PR DESCRIPTION
We moved to the new meeting platform after we created this agenda automation. I am not sure how to automate the date part, but the meeting link doesn't change so let's put it in the template.