### PR TITLE
Update workflow to run every Tuesday but only create a meeting every other week

### DIFF
--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -3,7 +3,7 @@ name: Create meeting template
 on:
   workflow_dispatch: {}
   schedule:
-    # every two weeks on tuesday at 10AM PST (with DST)
+    # every week on tuesday at 10AM PST (with DST)
     - cron: '0 17 * * 2'
 
 jobs:


### PR DESCRIPTION
The current cron runs only on the 1, 15 and 29 of the month (every 14 days) if they are Tuesdays, so it hasn't been creating meetings. This change adjusts the workflow to run every week but only create next week's meeting every OTHER week.