### PR TITLE
ci: adds condition so the publish workflow only runs upstream

### DIFF
--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   publish:
+    if: github.repository == 'OAI/Overlay-Specification'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
this adds a condition to the publish workflow similar to the respec one so it stops continuously failing and create noise on forks.