### PR TITLE
ci: updates node to 22 to stay on a secure version

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v6 # setup Node.js
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v6 # setup Node.js
         with:
-          node-version: 20.x
+          node-version: "22.x"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/schema-tests.yaml
+++ b/.github/workflows/schema-tests.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v6 # setup Node.js
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/validate-markdown.yaml
+++ b/.github/workflows/validate-markdown.yaml
@@ -25,7 +25,7 @@ jobs:
       #     git checkout remotes/origin/main -- package.json package-lock.json .markdownlint.yaml
       - uses: actions/setup-node@v6 # setup Node.js
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - name: Validate markdown
         run: npx --yes mdv versions/*.md
       - name: Lint markdown


### PR DESCRIPTION
this pull request updates our CI to node 22 since node 20 has only 6 months of shelf-life left before it turns into a pumpkin