### PR TITLE
md2html: correct use of new yargs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
-        "@hyperjump/json-schema": "^1.9.9",
         "@hyperjump/json-schema-coverage": "^1.1.1",
         "c8": "^10.1.3",
         "markdownlint-cli": "^0.45.0",

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -15,12 +15,12 @@ const url = require('url');
 const hljs = require('highlight.js');
 const cheerio = require('cheerio');
 
-let argv = require('yargs')
+let argv = require('yargs')(process.argv.slice(2))
     .string('maintainers')
     .alias('m','maintainers')
     .describe('maintainers','path to MAINTAINERS.md')
     .demandCommand(1)
-    .argv;
+    .parse();
 const abstract = 'What is the Overlay Specification?';
 let maintainers = [];
 let emeritus = [];


### PR DESCRIPTION
The dependabot update of yargs broke script `md2html.js`, see logs of latest runs of action `respec`, for example https://github.com/OAI/Overlay-Specification/actions/runs/18684556715/job/53273597821 - look into step "run main script".