### PR TITLE
ReSpec: ignore versions/X.Y.Z-dev.md files

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -19,7 +19,7 @@ cp -p ../../node_modules/respec/builds/respec-w3c.* ../../deploy/js/
 latest=1.0.0
 latestCopied=none
 lastMinor="-"
-for filename in $(ls -1 ../../versions/[123456789].*.md | sort -r) ; do
+for filename in $(ls -1 ../../versions/[1-9].[0-9].[0-9].md | sort -r) ; do
   version=$(basename "$filename" .md)
   minorVersion=${version:0:3}
   tempfile=../../deploy/overlay/v$version-tmp.html


### PR DESCRIPTION
Ignore work-in-progress specification source files when publishing to spec.openapis.org, only process `versions/X.Y.Z.md` files, not `*-dev.md` files.