### PR TITLE
Describe behavior for primitive values in update and remove

### DIFF
--- a/versions/1.1.0-dev.md
+++ b/versions/1.1.0-dev.md
@@ -169,17 +169,15 @@ actions:
 Alternatively, where only a small number of updates need to be applied to a large document, each [Action Object](#action-object) MAY be more targeted.
 
 ```yaml
-overlay: 1.0.0
+overlay: 1.1.0
 info:
   title: Targeted Overlay
   version: 1.0.0
 actions:
-  - target: $.paths['/foo'].get
-    update:
-      description: This is the new description
-  - target: $.paths['/bar'].get
-    update:
-      description: This is the updated description
+  - target: $.paths['/foo'].get.description
+    update: This is the new description
+  - target: $.paths['/bar'].get.description
+    update: This is the updated description
   - target: $.paths['/bar']
     update:
       post:


### PR DESCRIPTION
This applies the rules for merging property values to non-object `update` values and extends `remove` to primitive target nodes.

Note: these features are already fully supported by
- [Apigee Go Gen](https://apigee.github.io/apigee-go-gen/transform/commands/oas-overlay/)
- [bump-cli](https://www.npmjs.com/package/bump-cli#the-overlay-command)
- [BinkyLabs.OpenApi.Overlays - dotnet](https://github.com/BinkyLabs/openapi-overlays-dotnet)
- [speakeasy](https://www.speakeasy.com/docs/speakeasy-reference/cli/overlay)

and mostly supported by
- [OAS Patcher](https://github.com/mcroissant/oas_patcher)
- [openapi-format](https://github.com/thim81/openapi-format)

See https://github.com/ralfhandl/overlay-experiments for tests of these features with the mentioned Overlay tools.

Fixes #57
Closes #70