### PR TITLE
Consistent casing for headings

### DIFF
--- a/versions/1.1.0-dev.md
+++ b/versions/1.1.0-dev.md
@@ -337,15 +337,15 @@ paths:
 
 This approach allows inversion of control as to where the Overlay updates apply to the target document itself.
 
-#### Copy example
+#### Copy Example
 
 Copy actions behave similarly to `update` actions but source the new values to merge with the target from the document being transformed instead of providing them in the Overlay document. Copy actions MAY be used in sequence with `update` or `remove` actions to perform more advanced transformations like moving or renaming nodes.
 
-##### Simple copy
+##### Simple Copy
 
 This example shows how to copy all operations from the `items` path item to the `some-items` path item.
 
-###### Source description
+###### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -378,7 +378,7 @@ actions:
     description: 'copies recursively all elements from the "items" path item to the new "some-items" path item without ensuring the node exists before the copy'
 ```
 
-###### Result description
+###### Result Description
 
 ```yaml
 openapi: 3.1.0
@@ -402,11 +402,11 @@ paths:
           description: OK
 ```
 
-##### Ensure the target exists and copy
+##### Ensure the Target Exists and Copy
 
 This example shows how to copy all operations from the `items` path item to the `other-items` path item after first ensuring the target exists with an update action.
 
-###### Source description
+###### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -441,7 +441,7 @@ actions:
     description: 'copies recursively all elements from the "items" path item to the new "other-items" path item while ensuring the node exists before the copy'
 ```
 
-###### Result description
+###### Result Description
 
 ```yaml
 openapi: 3.1.0
@@ -466,7 +466,7 @@ paths:
           description: OK
 ```
 
-##### Move example
+##### Move Example
 
 This example shows how to rename the `items` path item to `new-items` using a sequence of overlay actions:
 
@@ -474,7 +474,7 @@ This example shows how to rename the `items` path item to `new-items` using a se
 2. Use a `copy` action to copy the source path item to the target.
 3. Use a `remove` action to delete the original source path item.
 
-###### Source description
+###### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -511,7 +511,7 @@ actions:
     description: 'moves (renames) the "items" path item to "new-items"'
 ```
 
-###### Result description
+###### Result Description
 
 ```yaml
 openapi: 3.1.0
@@ -548,14 +548,14 @@ The extensions may or may not be supported by the available tooling, but those m
 Overlay files MAY choose to follow the convention of a `purpose.overlay.yaml` file naming pattern.
 Other file naming conventions are also supported.
 
-### RFC9535 compliance
+### RFC9535 Compliance
 
 [[RFC9535]] is a recent specification and libraries implementing JSONPath support might predate the RFC. Those libraries might differ entirely (expressions syntax is incompatible), or implement additional capabilities (superset of the RFC). A tool or library MUST fully implement [[RFC9535]] when parsing and expanding JSONPath query expressions to be compliant with the Overlay specification.
 
 Interoperable Overlay Documents MUST use RFC9535 JSONPath query expressions and MUST NOT use tool-specific JSONPath extensions.
 
 
-### Comments in OpenAPI descriptions
+### Comments in OpenAPI Descriptions
 
 Some formats, like [YAML](https://yaml.org/) or [JSONC](https://jsonc.org/), support using comments which do not impact the semantic meaning of the description. Applying Overlay Actions to a description MAY result in the loss of such comments in the updated description. The exact behavior is specific to the tool implementing the Overlay Specification.
 


### PR DESCRIPTION
Use [title case](https://en.wikipedia.org/wiki/Title_case) for headings.