### PR TITLE
Add Examples table to spec

### DIFF
--- a/versions/1.1.0-dev.md
+++ b/versions/1.1.0-dev.md
@@ -161,21 +161,21 @@ Interoperable Overlay Documents MUST use RFC9535 JSONPath query expressions and 
 
 | Use Case                                                                        | Description                                                             |
 |---------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| <a href="#example-update">Update</a> objects                                    | How to **update** objects.                                              |
-| - <a href="#example-structured-update">Structured</a> update                    | - **Mirror** target document **structure** update example.              |
-| - <a href="#example-targeted-updates">Targeted</a> updates                      | - A **targeted update** example.                                        |
-| - <a href="#example-multiple-updates">Multiple target</a> updates               | - **Update multiple** target objects example                            |
-| - Update objects given a <a href="#example-labeled-updates">label</a>           | - Apply **updates** to **labeled** targets using `x-oai-traits` example |
-| <a href="#example-copy">Copy</a> objects                                        | How to **copy** objects.                                                |
-| - <a href="#example-simple-copy">Simple copy</a> of an object                   | - A **simple copy** object example.                                     |
-| - <a href="#example-verified-target-copy">Verified target copy</a> of an object | - **Copy** an object to a **verified target** example.                  |
-| <a href="#example-move">Move</a> objects                                        | How to **move** objects.                                                |
-| - <a href="#example-move-simple">Simple move</a> of an object                   | - **Move** an object example.                                           |
-| Modify <a href="#example-array">array</a> objects                               | How to **modify array** objects.                                        |
-| - <a href="#example-array-add-element">Add</a> an array element                 | - **Add** an **array element** example                                 |
-| - <a href="#example-array-remove-element">Remove</a> an array element           | - **Remove** an **array element** example                              |
-| - <a href="#example-array-move-element">Move</a> an array element               | - **Move** an **array element** example.                                |
-| - <a href="#example-array-replace-element">Replace</a> an array element         | - **Replace** an **array element** example.                             |
+| <a href="#update">Update</a> objects                                    | How to **update** objects.                                              |
+| - <a href="#structured-update">Structured</a> update                    | - **Mirror** target document **structure** update example.              |
+| - <a href="#targeted-updates">Targeted</a> updates                      | - A **targeted update** example.                                        |
+| - <a href="#multiple-updates">Multiple target</a> updates               | - **Update multiple** target objects example                            |
+| - Update objects given a <a href="#labeled-updates">label</a>           | - Apply **updates** to **labeled** targets using `x-oai-traits` example |
+| <a href="#copy">Copy</a> objects                                        | How to **copy** objects.                                                |
+| - <a href="#simple-copy">Simple copy</a> of an object                   | - A **simple copy** object example.                                     |
+| - <a href="#verified-target-copy">Verified target copy</a> of an object | - **Copy** an object to a **verified target** example.                  |
+| <a href="#move">Move</a> objects                                        | How to **move** objects.                                                |
+| - <a href="#move-simple">Simple move</a> of an object                   | - **Move** an object example.                                           |
+| Modify <a href="#array">array</a> objects                               | How to **modify array** objects.                                        |
+| - <a href="#array-add-element">Add</a> an array element                 | - **Add** an **array element** example                                 |
+| - <a href="#array-remove-element">Remove</a> an array element           | - **Remove** an **array element** example                              |
+| - <a href="#array-move-element">Move</a> an array element               | - **Move** an **array element** example.                                |
+| - <a href="#array-replace-element">Replace</a> an array element         | - **Replace** an **array element** example.                             |
 
 **Note:** All examples in this section are non-normative and are provided solely to illustrate the behavior defined in the preceding normative sections.
 
@@ -358,17 +358,15 @@ paths:
           description: OK
 ```
 
-<a name="example-copy"></a>
 ### Copy Examples
 
 Copy actions behave similarly to `update` actions but source the node from the document being transformed. Copy `actions` MAY be used in sequence with `update` or `remove` actions to perform more advanced transformations like moving or renaming nodes.
 
-<a name="example-simple-copy"></a>
 #### Simple Copy
 
 This example shows how to copy all operations from the `items` path item to the "some-items" path item.
 
-#### Source description
+#### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -401,7 +399,7 @@ actions:
     description: 'copies recursively all elements from the "items" path item to the new "some-items" path item without ensuring the node exists before the copy'
 ```
 
-#### Result description
+#### Result Description
 
 ```yaml
 openapi: 3.1.0
@@ -425,12 +423,11 @@ paths:
           description: OK
 ```
 
-<a name="example-verified-target-copy"></a>
 #### Verified Target Copy
 
 This example shows how to copy all operations from the `items` path item to the `other-items` path item after first ensuring the target exists with an update action.
 
-#### Source description
+#### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -465,7 +462,7 @@ actions:
     description: 'copies recursively all elements from the "items" path item to the new "other-items" path item while ensuring the node exists before the copy'
 ```
 
-#### Result description
+#### Result Description
 
 ```yaml
 openapi: 3.1.0
@@ -490,12 +487,10 @@ paths:
           description: OK
 ```
 
-<a name="example-move"></a>
 ### Move Examples
 
 A **move** operation works like a _rename_, using a sequence of actions — `update`, `copy`, then `remove` — to shift a value to a new location in the target document.
 
-<a name="example-move-simple"></a>
 #### Simple Move
 
 This example shows how to rename the `items` path item to `new-items` using a sequence of overlay actions:
@@ -504,7 +499,7 @@ This example shows how to rename the `items` path item to `new-items` using a se
 2. Use a `copy` action to copy the source path item to the target.
 3. Use a `remove` action to delete the original source path item.
 
-#### Source description
+#### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -541,7 +536,7 @@ actions:
     description: 'moves (renames) the "items" path item to "new-items"'
 ```
 
-#### Result description
+#### Result Description
 
 ```yaml
 openapi: 3.1.0
@@ -561,12 +556,10 @@ paths:
           description: OK
 ```
 
-<a name="example-array"></a>
 ### Array Examples
 
 These examples demonstrate how to modify array-valued fields using Overlay actions — specifically how to **add**, **remove**, **move**, and **replace** elements within arrays in the target document.
 
-<a name="example-array-add-element"></a>
 #### Add Array Element
 
 Array elements MAY be added using the `update` property.
@@ -583,7 +576,6 @@ actions:
       in: query
 ```
 
-<a name="example-array-remove-element"></a>
 #### Remove Array Element
 
 Array elements MAY be deleted using the `remove` property. Use of array indexes to remove array items SHOULD be avoided where possible, as indexes will change when items are removed.
@@ -598,7 +590,6 @@ actions:
     remove:
 ```
 
-<a name="example-array-move-element"></a>
 #### Move Array Element
 
 Array elements MAY be moved by combining `update`, `copy`, and `remove` actions.
@@ -628,7 +619,6 @@ actions:
     remove: true
 ```
 
-<a name="example-array-replace-element"></a>
 #### Replace Array Element
 
 Array elements MAY be replaced by selecting one or more matching elements and applying an `update` action to modify their properties. This is only applicable to arrays of objects—primitive-valued arrays can only be replaced in their entirety.
@@ -648,7 +638,7 @@ actions:
         maximum: 100
 ```
 
-#### Source description
+#### Source Description
 
 ```yaml
 openapi: 3.1.0
@@ -685,7 +675,7 @@ actions:
     description: 'moves (renames) the "items" path item to "new-items"'
 ```
 
-#### Result description
+#### Result Description
 
 ```yaml
 openapi: 3.1.0


### PR DESCRIPTION
Added an Examples table, and the rest of the changes followed from that to improve structure, clarity, and consistency _(with no normative changes)._

**Summary of changes**

* Added a quick-reference table summarizing all examples
* Promoted `Examples` to a top-level non-normative section
* Added *Array Move* and *Array Replace* examples
* Standardized headings and ordering (`Update`, `Copy`, `Move`, `Array`)
* Adjusted anchors, grammar, and appendix order (File Naming → A, Revision History → B)

All content above `## Examples` remains unchanged except to fix broken links.