### PR TITLE
Zero targets, or more than one

### DIFF
--- a/versions/1.1.0-dev.md
+++ b/versions/1.1.0-dev.md
@@ -107,7 +107,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 #### Action Object
 
-This object represents one or more changes to be applied to the target document at the location defined by the target JSONPath expression.
+This object represents one or more changes to be applied to the target document at the locations defined by the target JSONPath expression.
 
 ##### Fixed Fields
 
@@ -115,11 +115,13 @@ This object represents one or more changes to be applied to the target document 
 | ---- | :----: | ---- |
 | <a name="action-target"></a>target | `string` | **REQUIRED** A RFC9535 JSONPath query expression selecting nodes in the target document. |
 | <a name="action-description"></a>description | `string` | A description of the action. [[CommonMark]] syntax MAY be used for rich text representation. |
-| <a name="action-update"></a>update | Any | If the `target` selects an object node, the value of this field MUST be an object with the properties and values to merge with the selected node. If the `target` selects an array, the value of this field MUST be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true` or if the `copy` field contains a value. |
+| <a name="action-update"></a>update | Any | If the `target` selects object nodes, the value of this field MUST be an object with the properties and values to merge with each selected object. If the `target` selects array nodes, the value of this field MUST be an entry to append to each selected array. This field has no impact if the `remove` field of this action object is `true` or if the `copy` field contains a value. |
 | <a name="action-copy"></a>copy | `string` | A JSONPath expression selecting a single node to copy into the `target` nodes. If the `target` selects an object node, the value of this field MUST be an object with the properties and values to merge with the selected node. If the `target` selects an array, the value of this field MUST be an entry to append to the array. This field has no impact if the `remove` field of this action object is `true` or if the `update` field contains a value. |
-| <a name="action-remove"></a>remove | `boolean` | A boolean value that indicates that the target object or array MUST be removed from the the map or array it is contained in. The default value is `false`. |
+| <a name="action-remove"></a>remove | `boolean` | A boolean value that indicates that each of the target objects or arrays MUST be removed from the the map or array it is contained in. The default value is `false`. |
 
-The result of the `target` JSONPath expression MUST be zero or more objects or arrays (not primitive types or `null` values). Should the `target` JSONPath result in selecting two or more nodes, they MUST be either all objects or all arrays.
+The result of the `target` JSONPath expression MUST be zero or more objects or arrays (not primitive types or `null` values).
+If the `target` JSONPath expression selects zero nodes, the action succeeds without changing the target document.
+If the `target` JSONPath expression selects two or more nodes for an `update` or `copy` action, the selected nodes MUST be either all objects or all arrays.
 
 To update a primitive property value such as a string, the `target` expression should select the _containing_ object in the target document and `update` should contain an object with the property and its new primitive value.
 


### PR DESCRIPTION
Explicitly state that zero target nodes is a no-op.

Rephrase text to also cover two or more target nodes.