### PR TITLE
docs: changes description for x- field as its not supported for the object

### DIFF
--- a/compliant-sets/replace-servers-for-sandbox/overlay.yaml
+++ b/compliant-sets/replace-servers-for-sandbox/overlay.yaml
@@ -1,7 +1,7 @@
-overlay: 1.0.0
+overlay: 1.1.0
 info:
   title: Change server URL
-  x-description: Replace servers list with a single sandbox or local development URL for the API
+  description: Replace servers list with a single sandbox or local development URL for the API
   version: 1.0.0
 actions:
   - target: '$.servers'


### PR DESCRIPTION
Context: I'm using the compliant sets for unit tests in here https://github.com/BinkyLabs/openapi-overlays-dotnet/pull/139

One of the examples is not compliant because the info object does NOT support a description field today.

This PR changes it for an x- so the example is fully compliant with the specification.