### PR TITLE
ci: adds a condition so the matrix evaluation doesn't fail when empty

### DIFF
--- a/.github/workflows/agenda.yaml
+++ b/.github/workflows/agenda.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "MEETING_DATES=$MEETING_DATES" >> $GITHUB_OUTPUT
 
   create-discussion:
-    if: github.repository == 'OAI/Overlay-Specification'
+    if: github.repository == 'OAI/Overlay-Specification' && needs.get-next-dates.outputs.meeting_dates != '[]'
     needs: get-next-dates
     strategy:
       matrix:


### PR DESCRIPTION
when no dates are returned, the worklfow matrix evaluation fails. This is an attempt to fix it. https://github.com/OAI/Overlay-Specification/actions/runs/19474987974