### PR TITLE
feat: clarifies format interoperability

### DIFF
--- a/versions/1.1.0-dev.md
+++ b/versions/1.1.0-dev.md
@@ -38,7 +38,7 @@ An Overlay document that conforms to the Overlay Specification is itself a JSON 
 All field names in the specification are **case sensitive**.
 This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**.
 
-Overlay [schema](#schema) expose two types of fields: _fixed fields_, which have a declared name, and _patterned fields_, which have a declared pattern for the field name.
+The Overlay [schema](#schema) defines two types of fields: _fixed fields_, which have a declared name, and _patterned fields_, which have a declared pattern for the field name.
 
 Patterned fields MUST have unique names within the containing object.
 


### PR DESCRIPTION
fixes #236 

This pull request aligns the format considerations with the language and [structure used in OAI 3.2.0](https://spec.openapis.org/oas/v3.2.0.html#format) for better consistency and understanding.

Key differences with 3.2.0 are:

1. I removed the comment about HTTP case sensitivity since it does not really apply here.
2. I removed the note about API requests and responses bodies formats in relation with the document format since it doesn't really apply here.
3. Updated any mention of "OpenAPI" to "Overlay".

Remaining questions:

1. Should we have a note to say that the format of the OpenAPI and Overlay documents MAY be different?