### PR TITLE
docs: adds a clarification for different formats across documents

### DIFF
--- a/versions/1.1.0-dev.md
+++ b/versions/1.1.0-dev.md
@@ -37,7 +37,7 @@ An Overlay document that conforms to the Overlay Specification is itself a JSON 
 
 Implementations MUST support applying either JSON or YAML Overlay documents to
 [[OpenAPI|OpenAPI]] descriptions
-represented in either YAML for JSON format.
+represented in either YAML or JSON format.
 
 All field names in the specification are **case sensitive**.
 This includes all fields that are used as keys in a map, except where explicitly noted that keys are **case insensitive**.


### PR DESCRIPTION
fixes #260