### PR TITLE
docs: adds Ralf to the editors

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -4,6 +4,7 @@
 
 - Lorna Mitchell [@lornajane](https://github.com/lornajane)
 - Mike Kistler [@mikekistler](https://github.com/mikekistler)
+- Ralf Handl [@ralfhandl](https://github.com/ralfhandl)
 - Vincent Biret [@baywet](https://github.com/baywet)
 
 ## Emeritus


### PR DESCRIPTION
@ralfhandl has made over 30 PRs to support this new release, and I believe he should be in the list.

here is the script I ran to find potential additional editors

```powershell
gh pr list -s closed -L 100 --json author | ConvertFrom-Json | Select -ExpandProperty author | Select -ExpandProperty login | ? { -not .StartsWith('app') } | Select -Unique
```

Wich returned 

```
baywet
jamietanna
ralfhandl
lornajane
mpenet
```

mpenet and jamietanna sitting at 1 PR each.