### PR TITLE
ci: fixes schema publishing script to handle multiple versions

### DIFF
--- a/scripts/schema-publish.sh
+++ b/scripts/schema-publish.sh
@@ -4,6 +4,8 @@
 
 # Run this script from the root of the repo. It is designed to be run by a GitHub workflow.
 
+shopt -s nullglob
+
 if [ -z "$1" ]; then
   schemaDirs=(schemas/v[1-9].[0-9])
   deployRoot="./deploy/overlay"
@@ -59,7 +61,7 @@ publish_schema() {
   fi
 }
 
-for schemaDir in $schemaDirs; do
+for schemaDir in "${schemaDirs[@]}"; do
   vVersion=$(basename "$schemaDir")
   version=${vVersion:1}
   deploydir="$deployRoot/$version"


### PR DESCRIPTION
the schema generation logic only works with a single version due to bash shanenigans. See this faulty PR https://github.com/OAI/spec.openapis.org/pull/48
This is an attempt to solve that