### PR TITLE
Add Bielu.AspNetCore.ApiDescriptions to the list of Overlay tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you are looking for tools to use with Overlays, try these:
 - [oas-overlay-java](https://github.com/IBM/oas-overlay-java)
 - [Specmatic](https://specmatic.io/) - [Docs](https://docs.specmatic.io/documentation/contract_tests.html#overlays)
 - [BinkyLabs.OpenApi.Overlays - dotnet](https://github.com/BinkyLabs/openapi-overlays-dotnet)
+- [Bielu.AspNetCore.ApiDescriptions - dotnet](https://github.com/bielu/Bielu.AspNetCore.ApiDescriptions)
 - [Legba - Clojure OpenAPI toolkit](https://github.com/mpenet/legba?tab=readme-ov-file#openapi-overlay-support)
 - [Zuplo CLI](https://zuplo.com/docs/guides/openapi-overlays)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are looking for tools to use with Overlays, try these:
 - [oas-overlay-java](https://github.com/IBM/oas-overlay-java)
 - [Specmatic](https://specmatic.io/) - [Docs](https://docs.specmatic.io/documentation/contract_tests.html#overlays)
 - [BinkyLabs.OpenApi.Overlays - dotnet](https://github.com/BinkyLabs/openapi-overlays-dotnet)
-- [Bielu.AspNetCore.ApiDescriptions - dotnet](https://github.com/bielu/Bielu.AspNetCore.ApiDescriptions)
+- [Bielu.AspNetCore.ApiDescriptions - dotnet](https://github.com/bielu/Bielu.AspNetCore.ApiDescriptions) - [Docs](https://apidescriptions.bielu.pl/)
 - [Legba - Clojure OpenAPI toolkit](https://github.com/mpenet/legba?tab=readme-ov-file#openapi-overlay-support)
 - [Zuplo CLI](https://zuplo.com/docs/guides/openapi-overlays)
 


### PR DESCRIPTION
## Summary
- Adds [Bielu.AspNetCore.ApiDescriptions](https://github.com/bielu/Bielu.AspNetCore.ApiDescriptions) to the "Tools that Support Overlays" list in the README.

## Test plan
- N/A (documentation-only change)